### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ site_description: A Python tool for flood impacts on human health
 site_url: https://https://deltares.github.io/FloodsAndHealthTool/
 
 repo_url: https://github.com/Deltares/FloodsAndHealthTool/
-edit_uri: edit/master/docs
+edit_uri: docs
 
 
 ### Build settings ###


### PR DESCRIPTION
Hi All,

Ik zag deze link https://deltares.github.io/FloodsAndHealthTool/
Waarvan de basis is gegenereerd in de mkdocs.yml file. Ooit door Marc.

Wanneer je deze pagina opent (https://deltares.github.io/FloodsAndHealthTool/ ) dan kan je op edit in GitHub klikken. Maar dat werkte niet. Volgens mij klopt de verwijzing niet in de mkdocs.yml file, daar staat edit_uri: edit/master/docs maar dat moet zijn edit_uri: docs [denk ik]

Klopt dat?

Dit is mijn eerste pull request ooit :-)

Gertjan